### PR TITLE
pr: [Nightly Fix] - Bug - Fix Alternate Row Color Guard

### DIFF
--- a/app/Views/public/ninja-footable-css.php
+++ b/app/Views/public/ninja-footable-css.php
@@ -218,7 +218,7 @@
         border-color: <?php echo esc_attr($colors['table_color_border']); ?> !important;
         }
     <?php endif; ?>
-    <?php if(isset($css_prefix['alternate_color_status']) && $css_prefix['alternate_color_status'] == 'yes'): ?>
+    <?php if(isset($colors['alternate_color_status']) && $colors['alternate_color_status'] == 'yes'): ?>
         <?php echo esc_attr($stackPrefix); ?> tbody tr:nth-child(even) {
         background-color: <?php echo esc_attr($colors['table_alt_color_primary']); ?>;
         color: <?php echo esc_attr($colors['table_alt_color_secondary']); ?>;


### PR DESCRIPTION
## What
- fix the alternate row color condition in the public table CSS template

## Why
- the template checked `alternate_color_status` on `$css_prefix`, which is a selector string, not the colors array
- on PHP 8 this can raise invalid offset warnings and it prevents zebra striping from honoring the saved setting

## Fix
- read `alternate_color_status` from `$colors`, which is the actual settings array used by the surrounding template

## Confidence
- linted `app/Views/public/ninja-footable-css.php` with `php -l`