### PR TITLE
pr: [Nightly Fix] - Bug - Fix Row ID Column Fallback

### DIFF
--- a/app/Hooks/Handlers/PublicDataHandler.php
+++ b/app/Hooks/Handlers/PublicDataHandler.php
@@ -190,7 +190,7 @@ class PublicDataHandler
                 $dataArray = array_values($data);
 
                 if (isset($dataArray[$column])) {
-                    $value = $data[$column];
+                    $value = $dataArray[$column];
                     if (is_array($value)) {
                         $value = $this->processCellInfoArray($value, $column, $id);
                     }


### PR DESCRIPTION
## What
- fix the `ninja_table_cell` shortcode fallback path when a cell is requested by `row_id`

## Why
- the code correctly checks the numeric fallback array, but then still reads from the original keyed array
- numeric column requests can therefore return an empty value or trigger undefined index notices even when the fallback data exists

## Fix
- use the resolved numeric fallback value from `array_values($data)` when the named column lookup misses

## Confidence
- linted `app/Hooks/Handlers/PublicDataHandler.php` with `php -l`