### PR TITLE
pr: [Nightly Fix] - Null Safety - Guard Empty Imports

### DIFF
--- a/app/Http/Controllers/ImportController.php
+++ b/app/Http/Controllers/ImportController.php
@@ -103,7 +103,25 @@ class ImportController extends Controller
             ], 423);
         }
 
+        if (empty($reader)) {
+            return $this->sendError([
+                'data' => [
+                    'errors'  => array(),
+                    'message' => __('The imported CSV file is empty.', 'ninja-tables')
+                ]
+            ], 423);
+        }
+
         $header = array_shift($reader);
+
+        if (empty($header) || !is_array($header)) {
+            return $this->sendError([
+                'data' => [
+                    'errors'  => array(),
+                    'message' => __('The imported CSV file is missing a header row.', 'ninja-tables')
+                ]
+            ], 423);
+        }
 
         $tableId = $this->createTable(array(
             'post_title'   => $fileName,
@@ -425,6 +443,13 @@ class ImportController extends Controller
         }
 
         $data = ninja_tables_sanitize_array($data);
+
+        if (empty($data)) {
+            return $this->sendError([
+                'errors'  => array(),
+                'message' => __('The imported file does not contain any rows.', 'ninja-tables')
+            ], 423);
+        }
 
         $tableId = $this->savedDragAndDropTable($data, $fileName);
 


### PR DESCRIPTION
## What
- reject empty import payloads before creating a table or dereferencing the first row

## Why
- empty CSV and drag-and-drop imports can currently flow through to code paths that assume at least one row exists
- that can lead to undefined offset access and blank table records being created from invalid input

## Fix
- add explicit empty-file and missing-header checks in the CSV importer
- add an early guard in the drag-and-drop/import-from-URL path when no rows were parsed

## Confidence
- linted `app/Http/Controllers/ImportController.php` with `php -l`