### PR TITLE
pr: [Nightly Fix] - Security - Enforce TLS Verification

### DIFF
--- a/app/Hooks/Handlers/DeactivationHandler.php
+++ b/app/Hooks/Handlers/DeactivationHandler.php
@@ -33,9 +33,8 @@ class DeactivationHandler
                 'ninja_doing_action' => 'deactivate'
             );
             wp_remote_post(self::$apiUrl, array(
-                'method'    => 'POST',
-                'sslverify' => false,
-                'body'      => $data
+                'method' => 'POST',
+                'body'   => $data
             ));
         }
     }
@@ -147,8 +146,7 @@ class DeactivationHandler
 
         wp_remote_post(static::$apiUrl, array(
             'method' => 'POST',
-            'sslverify' => false,
-            'body' => $data
+            'body'   => $data
         ));
 
         wp_send_json_success(array(

--- a/app/Modules/Lead/LeadOptIn.php
+++ b/app/Modules/Lead/LeadOptIn.php
@@ -73,9 +73,8 @@ class LeadOptIn
             'ninja_doing_action' => 'activate'
         );
         wp_remote_post($this->apiUrl, array(
-            'method'    => 'POST',
-            'sslverify' => false,
-            'body'      => $data
+            'method' => 'POST',
+            'body'   => $data
         ));
     }
 


### PR DESCRIPTION
## What
- remove the explicit `sslverify => false` overrides from outbound feedback and telemetry requests

## Why
- these requests send user and site metadata to a remote endpoint
- disabling certificate verification weakens transport security and creates avoidable MITM exposure

## Fix
- rely on WordPress default TLS verification for the deactivation and lead opt-in request paths

## Confidence
- linted `app/Hooks/Handlers/DeactivationHandler.php` and `app/Modules/Lead/LeadOptIn.php` with `php -l`