### PR TITLE
pr: [Nightly Fix] - Security - Restrict Public Edit Link

### DIFF
--- a/app/Views/public/ninja-footable.php
+++ b/app/Views/public/ninja-footable.php
@@ -39,7 +39,7 @@
         </div>
     <?php endif; ?>
 
-    <?php if (is_user_logged_in() && ninja_table_admin_role()): ?>
+    <?php if (is_user_logged_in() && current_user_can(ninja_table_admin_role())): ?>
         <a class="nt_edit_link" href="<?php echo esc_url(admin_url('admin.php?page=ninja_tables#/tables/' . $table->ID)); ?>">
             <?php esc_attr_e('Edit Table', 'ninja-tables') ?>
         </a>


### PR DESCRIPTION
## What
- tighten the frontend edit-link check to require the actual admin capability instead of a truthy role slug

## Why
- the existing condition shows the edit link to any logged-in user because `ninja_table_admin_role()` returns a non-empty string
- subscribers and customers should not see admin edit affordances on the public table output

## Fix
- replace the role-slug truthiness check with `current_user_can(ninja_table_admin_role())`

## Confidence
- linted `app/Views/public/ninja-footable.php` with `php -l`