### PR TITLE
pr: [Nightly Fix] - Typo - Polish User Facing Copy

### DIFF
--- a/app/Hooks/Handlers/DeactivationHandler.php
+++ b/app/Hooks/Handlers/DeactivationHandler.php
@@ -105,7 +105,7 @@ class DeactivationHandler
             "does_not_work" => array(
                 "label"              => "The plugin didn't work",
                 "custom_placeholder" => "",
-                "custom_label"       => 'Kindly tell us any suggestion so we can improve',
+                "custom_label"       => 'Please share any suggestions so we can improve.',
                 'has_custom'         => true
             ),
             "temporary"     => array(

--- a/app/Modules/DataProviders/NinjaFooTable.php
+++ b/app/Modules/DataProviders/NinjaFooTable.php
@@ -73,7 +73,7 @@ class NinjaFooTable
             'i18n'                     => array(
                 'search_in'      => __('Search in', 'ninja-tables'),
                 'search'         => __('Search', 'ninja-tables'),
-                'empty_text'     => __('No Result Found', 'ninja-tables'),
+                'empty_text'     => __('No Results Found', 'ninja-tables'),
                 'clear_all'      => __('Clear All', 'ninja-tables'),
                 'caption_format' => __('Selected', 'ninja-tables'),
                 'pikaday' => [
@@ -381,7 +381,7 @@ class NinjaFooTable
                 'search'         => (isset($settings['search_placeholder']))
                     ? sanitize_text_field($settings['search_placeholder']) : __('Search', 'ninja-tables'),
                 'no_result_text' => (isset($settings['no_result_text']))
-                    ? sanitize_text_field($settings['no_result_text']) : __('No Result Found', 'ninja-tables'),
+                    ? sanitize_text_field($settings['no_result_text']) : __('No Results Found', 'ninja-tables'),
             ),
             'shouldNotCache'        => isset($settings['shouldNotCache']) ? $settings['shouldNotCache'] : false,
             'skip_rows'             => Arr::get($settings, 'skip_rows', 0),


### PR DESCRIPTION
## What
- clean up a few awkward user-facing strings in the plugin UI

## Why
- the empty-state message is grammatically off
- the deactivation feedback prompt reads awkwardly and looks unpolished in admin

## Fix
- change `No Result Found` to `No Results Found`
- rewrite the deactivation prompt to `Please share any suggestions so we can improve.`

## Confidence
- linted `app/Hooks/Handlers/DeactivationHandler.php` and `app/Modules/DataProviders/NinjaFooTable.php` with `php -l`