### PR TITLE
pr: [Nightly Fix] - Security - Harden Inline JSON Output

### DIFF
--- a/app/Hooks/Handlers/EditorBlockHandler.php
+++ b/app/Hooks/Handlers/EditorBlockHandler.php
@@ -51,7 +51,7 @@ class EditorBlockHandler
                 title: '<?php esc_html_e('Insert Ninja Tables Shortcode', 'ninja-tables'); ?>',
                 select_error: '<?php esc_html_e('Please select a table', 'ninja-tables'); ?>',
                 insert_text: '<?php esc_html_e('Insert Shortcode', 'ninja-tables'); ?>',
-                tables: <?php echo json_encode($tables); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped $tables is already escaped before being passed in. ?>,
+                tables: <?php echo wp_json_encode($tables); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped $tables is already escaped before being passed in. ?>,
                 logo: '<?php echo esc_url(NINJA_TABLES_DIR_URL . 'assets/img/ninja-table-editor-button-2x.png'); ?>'
             }
         </script>

--- a/app/Modules/DataProviders/NinjaFooTable.php
+++ b/app/Modules/DataProviders/NinjaFooTable.php
@@ -524,7 +524,7 @@ class NinjaFooTable
                 $cartItems = WC()->cart->get_cart();
                 ?>
                 <script type="text/javascript">
-                    window['ninjaTableCartItems'] = <?php echo json_encode($cartItems); ?>;
+                    window['ninjaTableCartItems'] = <?php echo wp_json_encode($cartItems); ?>;
                 </script>
                 <?php
             });
@@ -768,7 +768,7 @@ class NinjaFooTable
         add_action('wp_footer', function () use ($vars, $table_id, $table_instance_name) {
             ?>
             <script type="text/javascript">
-                window['<?php echo esc_attr($table_instance_name);?>'] = <?php echo json_encode($vars, true); ?>
+                window['<?php echo esc_attr($table_instance_name);?>'] = <?php echo wp_json_encode($vars); ?>
             </script>
             <?php
         });


### PR DESCRIPTION
## What
- replace raw `json_encode` calls used inside inline `<script>` tags with `wp_json_encode`

## Why
- these values are injected into HTML script contexts
- WordPress provides `wp_json_encode` specifically to produce safer JSON output for frontend rendering and avoid edge-case script-breaking payloads

## Fix
- update the TinyMCE table payload and two public inline JS payloads to use `wp_json_encode`

## Confidence
- linted `app/Hooks/Handlers/EditorBlockHandler.php` and `app/Modules/DataProviders/NinjaFooTable.php` with `php -l`