### PR TITLE
pr: [Nightly Fix] - Security - Restrict Preview Access

### DIFF
--- a/app/Hooks/Handlers/PreviewHandler.php
+++ b/app/Hooks/Handlers/PreviewHandler.php
@@ -16,7 +16,9 @@ class PreviewHandler
         }
 
         if ($tableId) {
-            if (ninja_table_admin_role()) {
+            $role = ninja_table_admin_role();
+
+            if ($role && current_user_can($role)) {
                 do_action('ninja_tables_will_render_table', $tableId);
 
                 wp_enqueue_style('ninja-tables-preview',
@@ -39,7 +41,9 @@ class PreviewHandler
     public function dragAndDropTable()
     {
         if (isset($_GET['ninjatable_builder_preview']) && intval(wp_unslash($_GET['ninjatable_builder_preview']))) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-            if (ninja_table_admin_role()) {
+            $role = ninja_table_admin_role();
+
+            if ($role && current_user_can($role)) {
                 $tableId = intval(wp_unslash($_GET['ninjatable_builder_preview'])); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 
                 do_action('ninja_tables_will_render_table', $tableId);


### PR DESCRIPTION
## What
- require the current user to actually have the Ninja Tables admin capability before rendering table preview endpoints

## Why
- the preview handlers were checking whether ninja_table_admin_role() returned a role string, not whether the current visitor had that capability
- unauthenticated visitors could load admin preview output by hitting the preview query args directly

## Fix
- resolve the role once per preview handler
- gate both preview endpoints behind an explicit capability check for the current user

## Confidence
- linted app/Hooks/Handlers/PreviewHandler.php with php -l