### PR TITLE
pr: [Nightly Fix] - Null Safety - Guard Missing Duplicate Source

### DIFF
--- a/app/Http/Controllers/TablesController.php
+++ b/app/Http/Controllers/TablesController.php
@@ -120,6 +120,12 @@ class TablesController extends Controller
 
         $post = get_post($oldPostId);
 
+        if (!$post || $post->post_type !== $this->cptName) {
+            $this->json(array(
+                'message' => __('Table not found.', 'ninja-tables')
+            ), 404);
+        }
+
         // Duplicate table itself.
         $attributes = array(
             'post_title'   => $post->post_title . '( Duplicate )',


### PR DESCRIPTION
## What
- guard the duplicate-table endpoint when the requested source table no longer exists or is not a Ninja Tables post

## Why
- the duplicate action only checked that the ID was non-zero before dereferencing the post object
- requests targeting deleted or invalid IDs could call post properties on null and crash the handler instead of returning a clean error

## Fix
- validate the loaded post before duplicating it
- return a 404 response when the source table is missing or invalid

## Confidence
- linted app/Http/Controllers/TablesController.php with php -l