### PR TITLE
pr: [Nightly Fix] - Null Safety - Guard Plugin API Errors

### DIFF
--- a/app/Http/Controllers/PluginInstallerController.php
+++ b/app/Http/Controllers/PluginInstallerController.php
@@ -61,6 +61,10 @@ class PluginInstallerController extends Controller
 
         $upgrader = new PluginInstaller(new AjaxInstaller());
         $api      = plugins_api('plugin_information', array('slug' => $slug, 'fields' => array('sections' => false)));
+        if (is_wp_error($api)) {
+            return $api;
+        }
+
         $result   = $upgrader->installPlugin($api->download_link);
 
         if (is_wp_error($result)) {


### PR DESCRIPTION
**Issue:** Plugin API responses were used without checking for `WP_Error`, causing fatal errors when the WordPress.org API is unreachable.

**Fix:** Added `is_wp_error()` check before accessing plugin data from the API response.