### PR TITLE
pr: [Nightly Fix] - Bug - Guard Missing Duplicate Source

### DIFF
--- a/app/Http/Controllers/TablesController.php
+++ b/app/Http/Controllers/TablesController.php
@@ -119,6 +119,11 @@ class TablesController extends Controller
         NinjaTableItemsMigrator::checkDBMigrations();
 
         $post = get_post($oldPostId);
+        if ( ! $post || $post->post_type !== $this->cptName) {
+            $this->json(array(
+                'message' => __('Table not found.', 'ninja-tables')
+            ), 404);
+        }
 
         // Duplicate table itself.
         $attributes = array(


### PR DESCRIPTION
**Issue:** The table duplication handler assumed the source table always exists without validating, leading to a silent failure or PHP warning when the table ID is invalid.

**Fix:** Added an existence check for the source table before proceeding with the duplicate operation.