### PR TITLE
pr: [Nightly Fix] - Null Safety - Guard Bulk Column Deletes

### DIFF
--- a/app/Http/Controllers/TablesController.php
+++ b/app/Http/Controllers/TablesController.php
@@ -190,8 +190,15 @@ class TablesController extends Controller
         $deletableKeys = Arr::get($request->all(), 'deletable_keys', []);
 
         $getAllColumns = get_post_meta($id, '_ninja_table_columns', true);
+        if ( ! is_array($getAllColumns)) {
+            $getAllColumns = [];
+        }
 
         $filteredColumns = array_values(array_filter($getAllColumns, function ($column) use ($deletableKeys) {
+            if ( ! is_array($column) || ! isset($column['key'])) {
+                return true;
+            }
+
             return ! in_array($column['key'], $deletableKeys);
         }));
 


### PR DESCRIPTION
**Issue:** Bulk column delete handler accessed column data without checking if the column array key exists, risking PHP notices/warnings on malformed requests.

**Fix:** Added `isset()` guard before accessing column properties during bulk delete.