### PR TITLE
pr: [Nightly Fix] - Null Safety - Guard Missing Row Updates

### DIFF
--- a/app/Http/Controllers/TableItemsController.php
+++ b/app/Http/Controllers/TableItemsController.php
@@ -80,6 +80,13 @@ class TableItemsController extends Controller
         $rowId = intval(Arr::get($request->all(), 'row_id'));
 
         $row = NinjaTableItem::where('id', $rowId)->first();
+        if ( ! $row) {
+            return $this->sendError([
+                'data' => [
+                    'message' => __('Row not found.', 'ninja-tables')
+                ]
+            ], 404);
+        }
 
         if (user_can_richedit()) {
             $data = ninja_tables_sanitize_table_content_array($request->all(), $row->table_id);


### PR DESCRIPTION
**Issue:** Row update handler did not verify the target row exists before applying changes, silently failing or emitting a PHP notice when the row ID is not found.

**Fix:** Added a row existence check with an early return and proper error response when the row is missing.