### PR TITLE
pr: [Nightly Fix] - Bug - Fix Initial Loader Detection

### DIFF
--- a/app/Views/public/ninja-footable.php
+++ b/app/Views/public/ninja-footable.php
@@ -33,7 +33,7 @@
     </table>
     <?php do_action('ninja_tables_after_table_print', $table, $table_vars); ?>
 
-    <?php if (strpos($table_classes, 'ninja_require_initial_hide') != false): ?>
+    <?php if (strpos($table_classes, 'ninja_require_initial_hide') !== false): ?>
         <div class="footable-loader">
             <span class="fooicon fooicon-loader"></span>
         </div>


### PR DESCRIPTION
**Issue:** `strpos()` was compared with `!= false` instead of `!== false`. When the class is found at position 0, `strpos()` returns `0`, which is falsy, so the loader div was never shown for tables with that class at the start of the string.

**Fix:** Changed comparison to strict `!== false` to correctly handle position 0.