### PR TITLE
pr: [Nightly Fix] - Bug - Fix Installer Activation Check

### DIFF
--- a/app/Services/BackgroundInstaller.php
+++ b/app/Services/BackgroundInstaller.php
@@ -25,7 +25,7 @@ class BackgroundInstaller
             // See if the plugin is installed already.
             if (isset($installed_plugins[$plugin_dir_url])) {
                 $installed = true;
-                $activate  = ! is_plugin_active($plugin_file);
+                $activate  = ! is_plugin_active($plugin_dir_url);
             }
 
             // Install this thing!


### PR DESCRIPTION
**Issue:** BackgroundInstaller checked plugin activation with only the plugin filename (e.g. `plugin.php`) instead of the full plugin basename (e.g. `ninja-charts/plugin.php`). This caused `is_plugin_active()` to always return false for already-active plugins, incorrectly re-triggering activation.

**Fix:** Use `$plugin_dir_url` (the full basename) instead of `$plugin_file` when calling `is_plugin_active()`.